### PR TITLE
chore: upgrade deprecated runtime versions to supported releases

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Upgrades Node.js from `18.x` (EOL April 2025) to `22.x` in `integration-tests.yml`
- Aligns integration tests with the Node versions already used in unit tests (`20.x`, `22.x`)

## Test plan
- [x] Confirm integration tests pass on Node 20 and 22
- [x] Verify no Node 18-specific APIs are relied upon in tests
